### PR TITLE
V1 parsing country & lanugage options

### DIFF
--- a/redirects.go
+++ b/redirects.go
@@ -160,7 +160,6 @@ func Parse(r io.Reader) (rules []Rule, err error) {
 				// grab the country and or language
 
 				parameters = nil
-				fmt.Println("options: ", options)
 				for _, token := range options {
 					// if we find something other than a key/pair past the `status code` place, error out
 					if !strings.ContainsAny(token, "=") {

--- a/redirects_example_test.go
+++ b/redirects_example_test.go
@@ -41,8 +41,9 @@ func Example() {
 		#/	/something	302	foo=bar
 		#/	/something	302	foo=bar bar=baz
 		#/	id=:id /blog/:id 302
-		/articles id=:id tag=:tag /posts/:tag/:id 301!
-		#/ 	/auzy		302 Country=au,nz
+		#/articles id=:id tag=:tag /posts/:tag/:id 301!
+		#/ 	/auzy 302 Country=au,nz
+		/israel/*  /israel/he/:splat  302  Country=au,nz Language=he
   `))
 
 	enc := json.NewEncoder(os.Stdout)


### PR DESCRIPTION
### Current status
* Added ability to parse after the `to` field in this standard : `from [a=:save1 b=value] to [code][!] [Country=x,y,z] [Language=x,y,z]`
* Added ability to store Country & language options from redirect rule into the redirect Rule object

### Future plans
V2 will be to refactor code, this will include easy to understand functions of the format:
* isOptions(token string) - checks to make sure the token is a Country  or Language option
* isStatusCode(token string) - "... token is a " status code with or without bang "!"
* isPath(token string) = "... token is a " valid path, in the sense that it either starts with "/", "http://", or "https://"

Suggestions welcomed! of course :grin: